### PR TITLE
Sort scenarios best to worst

### DIFF
--- a/src/Debt.ts
+++ b/src/Debt.ts
@@ -1,5 +1,5 @@
 import { IDebt, IPlottable } from "./interfacesAndEnums";
-import { MatlabArray } from "./tools";
+import { LinSpace } from "./tools";
 
 export class Debt implements IDebt
 {
@@ -83,7 +83,7 @@ export class Debt implements IDebt
     {
         return {
             "name": this.name,
-            "x": MatlabArray( 0, 1, this.balances.length ),
+            "x": LinSpace( 0, 1, this.balances.length ),
             "y": this.balances
         }
     }

--- a/src/forecastScenarioFactory.ts
+++ b/src/forecastScenarioFactory.ts
@@ -3,8 +3,8 @@ import { Income } from "./Income";
 import { Debt } from "./Debt";
 import { addNYearsToDate } from "./helpers";
 
-export const initialSavings = 500;
-export const numMonthsToProject = 12 * 40; // 40 years
+const initialSavings = 500;
+const numMonthsToProject = 12 * 40; // 40 years
 const mcDonaldsBaseMonthlySalary = 10200;
 const overTimeHourlyPay = 130;
 const bobsBirthday = new Date( 1959, 8, 7 );

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,8 +1,8 @@
-export function MatlabArray( start: number, increment: number, end: number ): number[]
+export function LinSpace( startValue: number, increment: number, endValue: number ): number[]
 {
     let result: number[] = [];
 
-    for ( let i = start; i < end; i += increment )
+    for ( let i = startValue; i < endValue; i += increment )
     {
         result.push( i );
     }


### PR DESCRIPTION
Resolves issue #2
Now sorting the scenarios so that those resulting in the earliest retirement date are on top.
Also made it so that scenarios which never allow retirement have POSITIVE_INFINITY (as opposed to -1) months as their numMonthsTillRetirement so they will be sorted properly.